### PR TITLE
Feature/layer upgrade

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "pixel_cnn"]
-	path = pixel_cnn
-	url = git+ssh://git@github.com/jramapuram/pixel-cnn-pp.git
 [submodule "async_fid"]
 	path = async_fid
 	url = git+ssh://git@github.com/jramapuram/async_fid.git

--- a/distributions.py
+++ b/distributions.py
@@ -4,12 +4,6 @@ import torch.nn.functional as F
 import torch.distributions as D
 
 
-from .utils import ones_like, eps, is_half
-from .pixel_cnn.utils import discretized_mix_logistic_loss, \
-    discretized_mix_logistic_loss_1d, sample_from_discretized_mix_logistic_1d, \
-    sample_from_discretized_mix_logistic
-
-
 def nll_activation(logits, nll_type, **kwargs):
     """ Helper to activate logits based on the NLL
         NOTE: ignores variance here!
@@ -20,14 +14,7 @@ def nll_activation(logits, nll_type, **kwargs):
     :rtype: torch.Tensor
 
     """
-    if nll_type == "disc_mix_logistic":
-        assert 'chans' in kwargs, "need channels for disc_mix_logistic"
-        fn = sample_from_discretized_mix_logistic_1d if kwargs['chans'] == 1 \
-            else sample_from_discretized_mix_logistic
-        # ideally do this, but needs parameterization
-        # return fn(logits, **kwargs)
-        return fn(logits, nr_mix=10)
-    elif nll_type == 'log_logistic_256':
+    if nll_type == 'log_logistic_256':
         assert len(logits.shape) == 4, "need 4-dim tensor for log-logistic-256"
         assert 'chans' in kwargs, "need channels for disc_mix_logistic"
 
@@ -35,20 +22,22 @@ def nll_activation(logits, nll_type, **kwargs):
             return torch.sigmoid(logits)
         else:
             logits_mu, logits_sigma = get_loc_and_scale(logits)
-            #return torch.bernoulli(F.sigmoid(logits_mu))
+            # return torch.bernoulli(F.sigmoid(logits_mu))
             return torch.sigmoid(logits_mu)
     elif nll_type == 'pixel_wise':
         return pixel_wise_activation(logits)
     elif nll_type == "gaussian":
         logits_mu, logits_sigma = get_loc_and_scale(logits)
-        #return D.Normal(loc=logits_mu, scale=logits_sigma).sample()
+        # return D.Normal(loc=logits_mu, scale=logits_sigma).sample()
         return logits_mu
     elif nll_type == "laplace":
         logits_mu, logits_sigma = get_loc_and_scale(logits)
-        #return D.Laplace(loc=logits_mu, scale=logits_sigma).sample()
+        # return D.Laplace(loc=logits_mu, scale=logits_sigma).sample()
         return torch.sigmoid(logits_mu)
     elif nll_type == "bernoulli":
         return torch.sigmoid(logits)
+    elif nll_type == "l2":
+        return logits
     else:
         raise Exception("unknown nll provided")
 
@@ -71,7 +60,7 @@ def pixel_wise_activation(logits):
     #                                              range(256, chans+1 , 256))], dim=1)
     activ = torch.cat([torch.argmax(logits[:, begin_c:end_c, :, :], dim=1).unsqueeze(1)
                        for begin_c, end_c in zip(range(0, chans, 256),
-                                                 range(256, chans+1 , 256))], dim=1)
+                                                 range(256, chans + 1, 256))], dim=1)
     return activ.type(torch.float32) / 255.0
 
 
@@ -87,6 +76,7 @@ def nll_has_variance(nll_str):
         'gaussian': True,
         'laplace': True,
         'pixel_wise': False,
+        'l2': False,
         'bernoulli': False,
         'log_logistic_256': True,
         'disc_mix_logistic': True
@@ -111,8 +101,8 @@ def nll(x, recon_x, nll_type):
         "bernoulli": nll_bernoulli,
         "laplace": nll_laplace,
         "pixel_wise": nll_pixel_wise,
+        "l2": nll_l2,
         "log_logistic_256": nll_log_logistic_256,
-        "disc_mix_logistic": nll_disc_mix_logistic
     }
     return nll_map[nll_type](x.contiguous(), recon_x.contiguous())
 
@@ -134,7 +124,7 @@ def nll_bernoulli(x, recon_x_logits):
 
 
 def pixel_wise_label(x):
-    """ Takes an image \in [0, 1], re-scales to 255 and returns the long-tensor
+    """ Takes an image in [0, 1], re-scales to 255 and returns the long-tensor
 
     :param x: input image
     :returns: label tensor
@@ -142,14 +132,14 @@ def pixel_wise_label(x):
 
     """
     assert x.max() <= 1 and x.min() >= 0, \
-        "pixel-wise label generation required x \in [0, 1], is [{}, {}]".format(x.min(), x.max())
+        "pixel-wise label generation required x in [0, 1], is [{}, {}]".format(x.min(), x.max())
     labels = (x * 255.0).type(torch.int64)
     # labels = F.one_hot(labels, num_classes=256)
     return labels
 
 
 def nll_pixel_wise(x, recon_x_logits):
-    """ NLL for pixel wise loss. Basically softmax cross-entropy \in [0, 255] per pixel.
+    """ NLL for pixel wise loss. Basically softmax cross-entropy in [0, 255] per pixel.
 
     :param x: the target tensor
     :param recon_x_logits: the predictions
@@ -166,24 +156,28 @@ def nll_pixel_wise(x, recon_x_logits):
     assert x.dim() == 4 and recon_x_logits.dim() == 4, "need 4d tensors for nll-pixelwise"
     assert chans % 256 == 0, "reconstruction needs to have chan dim be modulo 256"
 
-    #loss = torch.zeros(x.shape[0], device=x.device) # create a running buffer
+    # create a running buffer and corresponding targets
     loss = torch.zeros_like(x)
-    targets = pixel_wise_label(x)                   # re-scale to make the image its own labels
+    targets = pixel_wise_label(x)  # re-scale to make the image its own labels
 
-    for idx, (begin_c, end_c) in enumerate(zip(range(0, recon_x_logits.shape[1], 256),
-                                               range(256, recon_x_logits.shape[1]+1 , 256))):
-        loss_t = F.cross_entropy(input=recon_x_logits[:, begin_c:end_c, :, :],
-                                target=targets[:, idx, :, :], reduction='none')
+    @torch.jit.script
+    def _looped_cross_entropy(recon_x_logits, targets, loss):
+        for idx, (begin_c, end_c) in enumerate(zip(range(0, recon_x_logits.shape[1], 256),
+                                                   range(256, recon_x_logits.shape[1] + 1, 256))):
+            loss_t = F.cross_entropy(input=recon_x_logits[:, begin_c:end_c, :, :],
+                                     target=targets[:, idx, :, :], reduction='none')
 
-        # handle the grayscale issue
-        if loss_t.dim() < 4:
-            loss_t = loss_t.unsqueeze(1)
+            # handle the grayscale issue
+            if loss_t.dim() < 4:
+                loss_t = loss_t.unsqueeze(1)
 
-        loss += loss_t
+            loss += loss_t
 
-    loss /= chan_dims # remove channel contribution
+        return loss
+
+    loss = _looped_cross_entropy(recon_x_logits, targets, loss)
+    loss /= chan_dims  # remove channel contribution
     return torch.sum(loss.view(batch_size, -1), -1)
-
 
 
 def nll_log_logistic_256(x, recon_x_logits):
@@ -220,21 +214,6 @@ def nll_log_logistic_256(x, recon_x_logits):
     return torch.sum(log_logist_256, dim=-1)
 
 
-def nll_disc_mix_logistic(x, recon):
-    """ Discretized Log-Logistic Mixture used in PixelCNN++
-
-    :param x: the true tensor
-    :param recon: the reconstruction logits
-    :returns: batch size of NLL
-    :rtype: torch.Tensor
-
-    """
-    assert len(x.shape) == len(recon.shape) == 4, "expecting 4d input for discretized logistic loss"
-    fn = discretized_mix_logistic_loss_1d if x.shape[1] == 1 \
-        else discretized_mix_logistic_loss
-    return fn(x, recon)
-
-
 def get_loc_and_scale(recon):
     """ Helper to get the location and scale parameters by splitting a tensor.
 
@@ -257,12 +236,13 @@ def get_loc_and_scale(recon):
         recon_sigma = recon[:, :, num_half_chans:].contiguous()
     elif len(recon.shape) == 2:
         num_half_feat = recon.size(-1) // 2
-        recon_mu = recon[:, 0:num_half_chans].contiguous()
-        recon_sigma = recon[:, num_half_chans:].contiguous()
+        recon_mu = recon[:, 0:num_half_feat].contiguous()
+        recon_sigma = recon[:, num_half_feat:].contiguous()
     else:
         raise Exception("unknown dimension for gausian NLL")
 
     return recon_mu, recon_sigma
+
 
 def numerically_stable_exp(tensor, dim=-1):
     """ Removes largest value and exponentiates, returning both.
@@ -288,16 +268,17 @@ def nll_laplace(x, recon):
     """
     batch_size = x.size(0)
     loc, log_scale = get_loc_and_scale(recon)
-    #scale, max_val = numerically_stable_exp(log_scale.view(batch_size, -1))
+    # scale, max_val = numerically_stable_exp(log_scale.view(batch_size, -1))
     scale = torch.exp(log_scale)
 
-    # compute the NLL based on the flattened features
+    # TODO(jramapuram): consider the standard version below
     # nll = D.Laplace(
     #     loc=loc.view(batch_size, -1),
     #     # F.hardtanh(scale.view(batch_size, -1), min_val=-4.5, max_val=0) + 1e-6
     #     scale=scale.view(batch_size, -1)
     #     ).log_prob(x.view(batch_size, -1))
 
+    # compute the NLL based on the flattened features
     nll = -(math.log(2) + log_scale.view(batch_size, -1)) \
         - torch.abs(x.view(batch_size, -1) - loc.view(batch_size, -1)) / scale.view(batch_size, -1)
     return -torch.sum(nll, dim=-1)
@@ -314,20 +295,33 @@ def nll_gaussian(x, recon):
     """
     batch_size = x.size(0)
     loc, log_scale = get_loc_and_scale(recon)
-    #scale, max_val = numerically_stable_exp(log_scale.view(batch_size, -1))
+    # scale, max_val = numerically_stable_exp(log_scale.view(batch_size, -1))
     scale = torch.exp(log_scale)
 
-    var = scale ** 2
-    nll = -((x.view(batch_size, -1) - loc.view(batch_size, -1)) ** 2) / (2 * var.view(batch_size, -1)) \
-        - log_scale.view(batch_size, -1) - math.log(math.sqrt(2 * math.pi))
-
-    # nll = F.mse_loss(input=x.view(batch_size, -1),
-    #                  target=loc.view(batch_size, -1),
-    #                  reduction='none')
-
+    # TODO(jramapuram): consider the standard version below
     # nll = D.Normal(loc=loc.view(batch_size, -1),
     #                #scale=torch.clamp(scale.view(batch_size, -1), eps(is_half(x)), 0.999) # sigm can be 0 --> -inf -inf = nan
     #                scale=scale
     # ).log_prob(x.view(batch_size, -1))
 
+    # compute the NLL based on the flattened features
+    var = scale ** 2
+    nll = -((x.view(batch_size, -1) - loc.view(batch_size, -1)) ** 2) / (2 * var.view(batch_size, -1)) \
+        - log_scale.view(batch_size, -1) - math.log(math.sqrt(2 * math.pi))
     return -torch.sum(nll, dim=-1)
+
+
+def nll_l2(x, recon):
+    """ L2 loss proxy for gaussian likelihood without variance term.
+
+    :param x: true target
+    :param recon: the reconstruction logits
+    :returns: batch size NLL
+    :rtype: torch.Tensor
+
+    """
+    batch_size = x.size(0)
+    nll = F.mse_loss(input=x.view(batch_size, -1),
+                     target=recon.view(batch_size, -1),
+                     reduction='none')
+    return torch.sum(nll, dim=-1)

--- a/layers.py
+++ b/layers.py
@@ -1392,30 +1392,30 @@ class Attention(nn.Module):
 
 
 class Conv32UpsampleDecoder(nn.Module):
-    def __init__(self, input_chans, output_chans, base_channels=1024, channel_multiplier=0.5,
+    def __init__(self, input_size, output_chans, base_channels=1024, channel_multiplier=0.5,
                  activation_str="relu", normalization_str="none", norm_first_layer=True,
                  norm_last_layer=False, layer_fn=UpsampleConvLayer):
         super(Conv32UpsampleDecoder, self).__init__()
-        assert isinstance(input_chans, (float, int)), "Expect input_size as float or int."
+        assert isinstance(input_size, (float, int)), "Expect input_size as float or int."
 
         # Handle pre-decoder normalization
         norm_layer = Identity()
         if norm_first_layer:
             norm_layer = add_normalization(norm_layer, normalization_str,
-                                           ndims=1, nfeatures=input_chans)
+                                           ndims=1, nfeatures=input_size)
 
         # Project to 4x4 first
         self.mlp_proj = nn.Sequential(
-            View([-1, input_chans]),
+            View([-1, input_size]),
             norm_layer,
-            add_normalization(nn.Linear(input_chans, input_chans*4*4),
-                              normalization_str, ndims=1, nfeatures=input_chans*4*4),
+            add_normalization(nn.Linear(input_size, input_size*4*4),
+                              normalization_str, ndims=1, nfeatures=input_size*4*4),
             str_to_activ_module(activation_str)(),
-            View([-1, input_chans, 4, 4]),
+            View([-1, input_size, 4, 4]),
         )
 
         # The main model
-        self.model = _build_conv_stack(input_chans=input_chans,
+        self.model = _build_conv_stack(input_chans=input_size,
                                        output_chans=output_chans,
                                        layer_fn=layer_fn,
                                        base_channels=base_channels,
@@ -1444,30 +1444,30 @@ class Conv32UpsampleDecoder(nn.Module):
 
 
 class Resnet32Decoder(nn.Module):
-    def __init__(self, input_chans, output_chans, base_channels=1024, channel_multiplier=0.5,
+    def __init__(self, input_size, output_chans, base_channels=1024, channel_multiplier=0.5,
                  activation_str="relu", normalization_str="none", norm_first_layer=True,
                  norm_last_layer=False, layer_fn=nn.Conv2d):
         super(Resnet32Decoder, self).__init__()
-        assert isinstance(input_chans, (float, int)), "Expect input_size as float or int."
+        assert isinstance(input_size, (float, int)), "Expect input_size as float or int."
 
         # Handle pre-decoder normalization
         norm_layer = Identity()
         if norm_first_layer:
             norm_layer = add_normalization(norm_layer, normalization_str,
-                                           ndims=1, nfeatures=input_chans)
+                                           ndims=1, nfeatures=input_size)
 
         # Project to 4x4 first
         self.mlp_proj = nn.Sequential(
-            View([-1, input_chans]),
+            View([-1, input_size]),
             norm_layer,
-            add_normalization(nn.Linear(input_chans, input_chans*4*4),
-                              normalization_str, ndims=1, nfeatures=input_chans*4*4),
+            add_normalization(nn.Linear(input_size, input_size*4*4),
+                              normalization_str, ndims=1, nfeatures=input_size*4*4),
             str_to_activ_module(activation_str)(),
-            View([-1, input_chans, 4, 4]),
+            View([-1, input_size, 4, 4]),
         )
 
         # The main model
-        self.model = _build_resnet_stack(input_chans=input_chans,
+        self.model = _build_resnet_stack(input_chans=input_size,
                                          output_chans=output_chans,
                                          layer_fn=layer_fn,
                                          base_channels=base_channels,
@@ -1498,30 +1498,30 @@ class Resnet32Decoder(nn.Module):
 
 
 class Resnet64Decoder(nn.Module):
-    def __init__(self, input_chans, output_chans, base_channels=1024, channel_multiplier=0.5,
+    def __init__(self, input_size, output_chans, base_channels=1024, channel_multiplier=0.5,
                  activation_str="relu", normalization_str="none", norm_first_layer=True,
                  norm_last_layer=False, layer_fn=nn.Conv2d):
         super(Resnet64Decoder, self).__init__()
-        assert isinstance(input_chans, (float, int)), "Expect input_size as float or int."
+        assert isinstance(input_size, (float, int)), "Expect input_size as float or int."
 
         # Handle pre-decoder normalization
         norm_layer = Identity()
         if norm_first_layer:
             norm_layer = add_normalization(norm_layer, normalization_str,
-                                           ndims=1, nfeatures=input_chans)
+                                           ndims=1, nfeatures=input_size)
 
         # Project to 4x4 first
         self.mlp_proj = nn.Sequential(
-            View([-1, input_chans]),
+            View([-1, input_size]),
             norm_layer,
-            add_normalization(nn.Linear(input_chans, input_chans*4*4),
-                              normalization_str, ndims=1, nfeatures=input_chans*4*4),
+            add_normalization(nn.Linear(input_size, input_size*4*4),
+                              normalization_str, ndims=1, nfeatures=input_size*4*4),
             str_to_activ_module(activation_str)(),
-            View([-1, input_chans, 4, 4]),
+            View([-1, input_size, 4, 4]),
         )
 
         # The main model
-        self.model = _build_resnet_stack(input_chans=input_chans,
+        self.model = _build_resnet_stack(input_chans=input_size,
                                          output_chans=output_chans,
                                          layer_fn=layer_fn,
                                          base_channels=base_channels,
@@ -1552,30 +1552,30 @@ class Resnet64Decoder(nn.Module):
 
 
 class Resnet128Decoder(nn.Module):
-    def __init__(self, input_chans, output_chans, base_channels=1024, channel_multiplier=0.5,
+    def __init__(self, input_size, output_chans, base_channels=1024, channel_multiplier=0.5,
                  activation_str="relu", normalization_str="none", norm_first_layer=True,
                  norm_last_layer=False, layer_fn=nn.Conv2d):
         super(Resnet128Decoder, self).__init__()
-        assert isinstance(input_chans, (float, int)), "Expect input_size as float or int."
+        assert isinstance(input_size, (float, int)), "Expect input_size as float or int."
 
         # Handle pre-decoder normalization
         norm_layer = Identity()
         if norm_first_layer:
             norm_layer = add_normalization(norm_layer, normalization_str,
-                                           ndims=1, nfeatures=input_chans)
+                                           ndims=1, nfeatures=input_size)
 
         # Project to 4x4 first
         self.mlp_proj = nn.Sequential(
-            View([-1, input_chans]),
+            View([-1, input_size]),
             norm_layer,
-            add_normalization(nn.Linear(input_chans, input_chans*4*4),
-                              normalization_str, ndims=1, nfeatures=input_chans*4*4),
+            add_normalization(nn.Linear(input_size, input_size*4*4),
+                              normalization_str, ndims=1, nfeatures=input_size*4*4),
             str_to_activ_module(activation_str)(),
-            View([-1, input_chans, 4, 4]),
+            View([-1, input_size, 4, 4]),
         )
 
         # The main model
-        self.model = _build_resnet_stack(input_chans=input_chans,
+        self.model = _build_resnet_stack(input_chans=input_size,
                                          output_chans=output_chans,
                                          layer_fn=layer_fn,
                                          base_channels=base_channels,
@@ -1606,14 +1606,14 @@ class Resnet128Decoder(nn.Module):
 
 
 class Conv32Decoder(nn.Module):
-    def __init__(self, input_chans, output_chans, base_channels=1024, channel_multiplier=0.5,
+    def __init__(self, input_size, output_chans, base_channels=1024, channel_multiplier=0.5,
                  activation_str="relu", normalization_str="none", norm_first_layer=False,
                  norm_last_layer=False, layer_fn=nn.ConvTranspose2d):
         super(Conv32Decoder, self).__init__()
-        assert isinstance(input_chans, (float, int)), "Expect input_size as float or int."
+        assert isinstance(input_size, (float, int)), "Expect input_size as float or int."
 
         # The main model
-        self.model = _build_conv_stack(input_chans=input_chans,
+        self.model = _build_conv_stack(input_chans=input_size,
                                        output_chans=output_chans,
                                        layer_fn=layer_fn,
                                        base_channels=base_channels,
@@ -1638,14 +1638,14 @@ class Conv32Decoder(nn.Module):
 
 
 class Conv64Decoder(nn.Module):
-    def __init__(self, input_chans, output_chans, base_channels=1024, channel_multiplier=0.5,
+    def __init__(self, input_size, output_chans, base_channels=1024, channel_multiplier=0.5,
                  activation_str="relu", normalization_str="none", norm_first_layer=True,
                  norm_last_layer=False, layer_fn=nn.ConvTranspose2d):
         super(Conv64Decoder, self).__init__()
-        assert isinstance(input_chans, (float, int)), "Expect input_size as float or int."
+        assert isinstance(input_size, (float, int)), "Expect input_size as float or int."
 
         # The main model
-        self.model = _build_conv_stack(input_chans=input_chans,
+        self.model = _build_conv_stack(input_chans=input_size,
                                        output_chans=output_chans,
                                        layer_fn=layer_fn,
                                        base_channels=base_channels,
@@ -1666,14 +1666,14 @@ class Conv64Decoder(nn.Module):
 
 
 class Conv128Decoder(nn.Module):
-    def __init__(self, input_chans, output_chans, base_channels=1024, channel_multiplier=0.5,
+    def __init__(self, input_size, output_chans, base_channels=1024, channel_multiplier=0.5,
                  activation_str="relu", normalization_str="none", norm_first_layer=True,
                  norm_last_layer=False, layer_fn=nn.ConvTranspose2d):
         super(Conv128Decoder, self).__init__()
-        assert isinstance(input_chans, (float, int)), "Expect input_size as float or int."
+        assert isinstance(input_size, (float, int)), "Expect input_size as float or int."
 
         # The main model
-        self.model = _build_conv_stack(input_chans=input_chans,
+        self.model = _build_conv_stack(input_chans=input_size,
                                        output_chans=output_chans,
                                        layer_fn=layer_fn,
                                        base_channels=base_channels,
@@ -1966,68 +1966,183 @@ class Conv128Encoder(nn.Module):
         return self.model(images)
 
 
-def _build_dense(input_shape, output_shape=None, output_size=None,
+def _build_dense(input_size,
+                 output_size,
                  layer_fn=nn.Linear,
                  latent_size=512, num_layers=2,
                  activation_str="elu", normalization_str="none",
-                 norm_first_layer=False, norm_last_layer=False,
-                 disable_flatten=False, **unused_kwargs):
+                 norm_first_layer=False, norm_last_layer=False):
     ''' flatten --> layer + norm --> activation -->... --> Linear output --> view'''
     assert normalization_str != "groupnorm", "Groupnorm not supported for dense models."
-    assert output_shape is not None or output_size is not None, "Need output_shape or output_size."
-    if output_size is not None:
-        assert output_shape is None, "Only provide output_shape or output_size."
-
-    if output_shape is not None:
-        assert output_size is not None, "Only provide output_shape or output_size."
-
-    # Sizing computations
-    input_flat = int(np.prod(input_shape))
-    output_flat = int(np.prod(output_shape)) if output_shape is not None else output_size
-    if output_shape is not None:
-        output_shape = [output_shape] if not isinstance(output_shape, list) else output_shape
-    else:
-        output_shape = [output_size]
 
     # Activation and normalization functions
     activation_fn = str_to_activ_module(activation_str)
     norm_fn = functools.partial(
         add_normalization, normalization_str=normalization_str, ndims=1)
 
-    # don't flatten if we passed 'disable_flatten' in kwargs
-    if disable_flatten and input_flat == input_shape:
-        view_init_layer = Identity()
-        view_final_layer = Identity()
-    else:
-        view_init_layer = View([-1, input_flat])
-        view_final_layer = View([-1] + output_shape)
-
     # add initial norm if requested
+    init_norm_layer = Identity()
     if norm_first_layer:
-        view_init_layer = norm_fn(view_init_layer, nfeatures=input_flat)
+        init_norm_layer = norm_fn(init_norm_layer, nfeatures=input_size)
 
     # add final norm if requested
-    norm_final_layer = Identity()
+    final_norm_layer = Identity()
     if norm_last_layer:
-        norm_final_layer = norm_fn(norm_final_layer, nfeatures=output_flat)
+        final_norm_layer = norm_fn(final_norm_layer, nfeatures=output_size)
 
-    layers = [('view0', view_init_layer),
-              ('l0', add_normalization(layer_fn(input_flat, latent_size),
-                                       normalization_str, 1, latent_size, num_groups=32)),
+    layers = [('init_norm', init_norm_layer),
+              ('l0', norm_fn(layer_fn(input_size, latent_size), nfeatures=latent_size)),
               ('act0', activation_fn())]
 
     for i in range(num_layers - 2):  # 2 for init layer[above] + final layer[below]
         layers.append(
-            ('l{}'.format(i+1), add_normalization(layer_fn(latent_size, latent_size),
-                                                  normalization_str, 1, latent_size, num_groups=32))
+            ('l{}'.format(i+1), norm_fn(layer_fn(latent_size, latent_size), nfeatures=latent_size)),
         )
         layers.append(('act{}'.format(i+1), activation_fn()))
 
-    layers.append(('output', layer_fn(latent_size, output_flat)))
-    layers.append(('output_norm', norm_final_layer))
-    layers.append(('viewout', view_final_layer))
-
+    layers.append(('output', layer_fn(latent_size, output_size)))
+    layers.append(('final_norm', final_norm_layer))
     return nn.Sequential(OrderedDict(layers))
+
+# def _build_dense(input_shape=None, input_size=None,    # provide either input_shape or input_size
+#                  output_shape=None, output_size=None,  # provide either output_shape or output_size
+#                  layer_fn=nn.Linear,
+#                  latent_size=512, num_layers=2,
+#                  activation_str="elu", normalization_str="none",
+#                  norm_first_layer=False, norm_last_layer=False,
+#                  disable_flatten=False, **unused_kwargs):
+#     ''' flatten --> layer + norm --> activation -->... --> Linear output --> view'''
+#     assert normalization_str != "groupnorm", "Groupnorm not supported for dense models."
+
+#     # Sanity on output_size + output_shape
+#     assert output_shape is not None or output_size is not None, "Need output_shape or output_size."
+#     if output_size is not None:
+#         assert output_shape is None, "Only provide output_shape or output_size."
+
+#     if output_shape is not None:
+#         assert output_size is not None, "Only provide output_shape or output_size."
+
+#     # Sanity on input_size + input_shape
+#     assert input_shape is not None or input_size is not None, "Need input_shape or input_size."
+#     if input_size is not None:
+#         assert input_shape is None, "Only provide input_shape or input_size."
+
+#     if input_shape is not None:
+#         assert input_size is not None, "Only provide input_shape or input_size."
+
+#     # Sizing computations
+#     input_shape = input_size if input_size is not None else input_shape
+#     input_flat = int(np.prod(input_shape))
+#     output_flat = int(np.prod(output_shape)) if output_shape is not None else output_size
+#     if output_shape is not None:
+#         output_shape = [output_shape] if not isinstance(output_shape, list) else output_shape
+#     else:
+#         output_shape = [output_size]
+
+#     # Activation and normalization functions
+#     activation_fn = str_to_activ_module(activation_str)
+#     norm_fn = functools.partial(
+#         add_normalization, normalization_str=normalization_str, ndims=1)
+
+#     # don't flatten if we passed 'disable_flatten' in kwargs
+#     if disable_flatten and input_flat == input_shape:
+#         view_init_layer = Identity()
+#         view_final_layer = Identity()
+#     else:
+#         view_init_layer = View([-1, input_flat])
+#         view_final_layer = View([-1] + output_shape)
+
+#     # add initial norm if requested
+#     if norm_first_layer:
+#         view_init_layer = norm_fn(view_init_layer, nfeatures=input_flat)
+
+#     # add final norm if requested
+#     norm_final_layer = Identity()
+#     if norm_last_layer:
+#         norm_final_layer = norm_fn(norm_final_layer, nfeatures=output_flat)
+
+#     layers = [('view0', view_init_layer),
+#               ('l0', add_normalization(layer_fn(input_flat, latent_size),
+#                                        normalization_str, 1, latent_size, num_groups=32)),
+#               ('act0', activation_fn())]
+
+#     for i in range(num_layers - 2):  # 2 for init layer[above] + final layer[below]
+#         layers.append(
+#             ('l{}'.format(i+1), add_normalization(layer_fn(latent_size, latent_size),
+#                                                   normalization_str, 1, latent_size, num_groups=32))
+#         )
+#         layers.append(('act{}'.format(i+1), activation_fn()))
+
+#     layers.append(('output', layer_fn(latent_size, output_flat)))
+#     layers.append(('output_norm', norm_final_layer))
+#     layers.append(('viewout', view_final_layer))
+
+#     return nn.Sequential(OrderedDict(layers))
+
+
+class Dense(nn.Module):
+    def __init__(self, input_shape, output_shape,
+                 latent_size=512, num_layers=2,
+                 activation_str="relu", normalization_str="none",
+                 norm_first_layer=False, norm_last_layer=False,
+                 layer_fn=nn.Linear):
+        super(Dense, self).__init__()
+        assert isinstance(input_shape, list), "input_shape needs to be a list."
+        assert isinstance(output_shape, list), "output_shape needs to be a list."
+        input_size = int(np.prod(input_shape))
+        output_size = int(np.prod(output_shape))
+
+        # the views and model
+        self.input_view = View([-1, input_size])
+        self.model = _build_dense(input_size=input_size,
+                                  output_size=output_size,
+                                  latent_size=latent_size,
+                                  num_layers=num_layers,
+                                  layer_fn=layer_fn,
+                                  activation_str=activation_str,
+                                  normalization_str=normalization_str,
+                                  norm_first_layer=norm_first_layer,
+                                  norm_last_layer=norm_last_layer)
+        self.output_view = View([-1, *output_shape])
+
+    def forward(self, inputs):
+        h = self.input_view(inputs)
+        h = self.model(h)
+        return self.output_view(h)
+
+
+class DenseEncoder(Dense):
+    def __init__(self, input_shape, output_size,
+                 latent_size=512, num_layers=2,
+                 activation_str="relu", normalization_str="none",
+                 norm_first_layer=False, norm_last_layer=False,
+                 layer_fn=nn.Linear):
+        super(DenseEncoder, self).__init__(input_shape=input_shape,
+                                           output_shape=[output_size],
+                                           latent_size=latent_size,
+                                           num_layers=num_layers,
+                                           activation_str=activation_str,
+                                           normalization_str=normalization_str,
+                                           norm_first_layer=norm_first_layer,
+                                           norm_last_layer=norm_last_layer,
+                                           layer_fn=layer_fn)
+
+
+class DenseDecoder(Dense):
+    def __init__(self, input_size, output_shape,
+                 latent_size=512, num_layers=2,
+                 activation_str="relu", normalization_str="none",
+                 norm_first_layer=False, norm_last_layer=False,
+                 layer_fn=nn.Linear):
+        super(DenseDecoder, self).__init__(input_shape=[input_size],
+                                           output_shape=output_shape,
+                                           latent_size=latent_size,
+                                           num_layers=num_layers,
+                                           activation_str=activation_str,
+                                           normalization_str=normalization_str,
+                                           norm_first_layer=norm_first_layer,
+                                           norm_last_layer=norm_last_layer,
+                                           layer_fn=layer_fn)
 
 
 def get_encoder(input_shape: Tuple[int, int, int],  # [C, H, W]
@@ -2038,6 +2153,7 @@ def get_encoder(input_shape: Tuple[int, int, int],  # [C, H, W]
                 dense_normalization: str = 'none',
                 conv_normalization: str = 'none',
                 disable_gated: bool = True,
+                norm_first_layer: bool = False,
                 norm_last_layer: bool = False,
                 activation: str = 'relu',
                 name: str = 'encoder',
@@ -2055,6 +2171,8 @@ def get_encoder(input_shape: Tuple[int, int, int],  # [C, H, W]
     }
     chans, image_size = input_shape[0], input_shape[-1]
 
+    # Mega-dict that curried the appropriate encoder.
+    # The returned encoder still needs the CTOR, eg: enc(input_shape)
     net_map = {
         'resnet50': {
             False: functools.partial(TorchvisionEncoder,
@@ -2139,20 +2257,20 @@ def get_encoder(input_shape: Tuple[int, int, int],  # [C, H, W]
         },
         'dense': {
             # True for gated, False for non-gated
-            True: functools.partial(_build_dense,
+            True: functools.partial(DenseEncoder,
                                     input_shape=input_shape,
                                     latent_size=latent_size,
                                     num_layers=3,  # XXX(jramapuram): hardcoded, can be over-ridden during init
-                                    norm_first_layer=False,  # input data
+                                    norm_first_layer=norm_first_layer,
                                     norm_last_layer=norm_last_layer,
                                     activation_str=activation,
                                     normalization_str=dense_normalization,
                                     layer_fn=GatedDense),
-            False: functools.partial(_build_dense,
+            False: functools.partial(DenseEncoder,
                                      input_shape=input_shape,
                                      latent_size=latent_size,
                                      num_layers=3,  # XXX(jramapuram): hardcoded, can be over-ridden during init
-                                     norm_first_layer=False,  # input data
+                                     norm_first_layer=norm_first_layer,
                                      norm_last_layer=norm_last_layer,
                                      activation_str=activation,
                                      normalization_str=dense_normalization,
@@ -2169,8 +2287,7 @@ def get_encoder(input_shape: Tuple[int, int, int],  # [C, H, W]
     return fn
 
 
-def get_decoder(input_size: int,                    # input size to decoder
-                output_shape: Tuple[int, int, int],  # output image shape [B, H, W]
+def get_decoder(output_shape: Tuple[int, int, int],  # output image shape [B, H, W]
                 decoder_layer_type: str = 'conv',
                 decoder_base_channels: int = 1024,      # For conv models
                 decoder_channel_multiplier: int = 0.5,  # Decoding shrinks channels
@@ -2195,14 +2312,14 @@ def get_decoder(input_size: int,                    # input size to decoder
         64: Resnet64Decoder,
         32: Resnet32Decoder,
     }
-
     image_size = output_shape[-1]
 
+    # Mega-dict that curried the appropriate decoder.
+    # The returned decoder still needs the CTOR, eg: dec(input_size)
     net_map = {
         'resnet': {
             # True for gated, False for non-gated
             True: functools.partial(resnet_size_dict[image_size],
-                                    input_chans=input_size,
                                     output_chans=output_shape[0],
                                     base_channels=decoder_base_channels,
                                     channel_multiplier=decoder_channel_multiplier,
@@ -2212,7 +2329,6 @@ def get_decoder(input_size: int,                    # input size to decoder
                                     activation_str=activation,
                                     layer_fn=functools.partial(GatedConv2d, layer_type=nn.Conv2d)),
             False: functools.partial(resnet_size_dict[image_size],
-                                     input_chans=input_size,
                                      output_chans=output_shape[0],
                                      base_channels=decoder_base_channels,
                                      channel_multiplier=decoder_channel_multiplier,
@@ -2224,7 +2340,6 @@ def get_decoder(input_size: int,                    # input size to decoder
         },
         'conv': {
             True: functools.partial(conv_size_dict[image_size],
-                                    input_chans=input_size,
                                     output_chans=output_shape[0],
                                     base_channels=decoder_base_channels,
                                     channel_multiplier=decoder_channel_multiplier,
@@ -2234,7 +2349,6 @@ def get_decoder(input_size: int,                    # input size to decoder
                                     activation_str=activation,
                                     layer_fn=functools.partial(GatedConv2d, layer_type=nn.ConvTranspose2d)),
             False: functools.partial(conv_size_dict[image_size],
-                                     input_chans=input_size,
                                      output_chans=output_shape[0],
                                      base_channels=decoder_base_channels,
                                      channel_multiplier=decoder_channel_multiplier,
@@ -2246,7 +2360,6 @@ def get_decoder(input_size: int,                    # input size to decoder
         },
         'batch_conv': {
             True: functools.partial(conv_size_dict[image_size],
-                                    input_chans=input_size,
                                     output_chans=output_shape[0],
                                     base_channels=decoder_base_channels,
                                     channel_multiplier=decoder_channel_multiplier,
@@ -2256,7 +2369,6 @@ def get_decoder(input_size: int,                    # input size to decoder
                                     activation_str=activation,
                                     layer_fn=functools.partial(GatedConv2d, layer_type=BatchConvTranspose2D)),
             False: functools.partial(conv_size_dict[image_size],
-                                     input_chans=input_size,
                                      output_chans=output_shape[0],
                                      base_channels=decoder_base_channels,
                                      channel_multiplier=decoder_channel_multiplier,
@@ -2268,7 +2380,6 @@ def get_decoder(input_size: int,                    # input size to decoder
         },
         'coordconv': {
             True: functools.partial(conv_size_dict[image_size],
-                                    input_chans=input_size,
                                     output_chans=output_shape[0],
                                     base_channels=decoder_base_channels,
                                     channel_multiplier=decoder_channel_multiplier,
@@ -2278,7 +2389,6 @@ def get_decoder(input_size: int,                    # input size to decoder
                                     activation_str=activation,
                                     layer_fn=functools.partial(GatedConv2d, layer_type=CoordConvTranspose)),
             False: functools.partial(conv_size_dict[image_size],
-                                     input_chans=input_size,
                                      output_chans=output_shape[0],
                                      base_channels=decoder_base_channels,
                                      channel_multiplier=decoder_channel_multiplier,
@@ -2290,8 +2400,7 @@ def get_decoder(input_size: int,                    # input size to decoder
         },
         'dense': {
             # True for gated, False for non-gated
-            True: functools.partial(_build_dense,
-                                    input_shape=input_size,
+            True: functools.partial(DenseDecoder,  # _build_dense,
                                     output_shape=output_shape,
                                     latent_size=latent_size,
                                     num_layers=3,  # XXX(jramapuram): hardcoded, can be over-ridden during init
@@ -2300,8 +2409,7 @@ def get_decoder(input_size: int,                    # input size to decoder
                                     activation_str=activation,
                                     normalization_str=dense_normalization,
                                     layer_fn=GatedDense),
-            False: functools.partial(_build_dense,
-                                     input_shape=input_size,
+            False: functools.partial(DenseDecoder,  # _build_dense,
                                      output_shape=output_shape,
                                      latent_size=latent_size,
                                      num_layers=3,  # XXX(jramapuram): hardcoded, can be over-ridden during init

--- a/utils.py
+++ b/utils.py
@@ -668,6 +668,7 @@ def get_name(args):
                            .replace('cosine', 'cos')
                            .replace('lars_', 'l')
                            .replace('momentum', 'mom')
+                           .replace('autoencoder', 'ae')
     )
 
     # sanity check to ensure filename is 255 chars or less for being able to write to filesystem
@@ -677,9 +678,7 @@ def get_name(args):
 
 def register_nan_checks(model):
     def check_grad(module, grad_input, grad_output):
-        # print(module) you can add this to see that the hook is called
-        #print(module)
-        if  any(np.all(np.isnan(gi.data.cpu().numpy())) for gi in grad_input if gi is not None):
+        if any(np.all(np.isnan(gi.data.cpu().numpy())) for gi in grad_input if gi is not None):
             print('NaN gradient in ' + type(module).__name__)
             exit(-1)
 

--- a/utils.py
+++ b/utils.py
@@ -626,7 +626,7 @@ def get_name(args):
     nonestr2bool = lambda v: 0 if isinstance(v, str) and v.lower().strip() == 'none' else v
     # clip2int = lambda v: int(v) if isinstance(v, (float, np.float32, np.float64)) and v == 0.0 else v
     clip2int = lambda v: int(v) if isinstance(v, float) and v - int(v) == 0 else v
-    filtered = {_factor(k):clip2int(nonestr2bool(none2bool(bool2int(v)))) for k,v in filtered.items()}
+    filtered = {_factor(k):clip2int(nonestr2bool(none2bool(bool2int(v)))) for k, v in filtered.items()}
     name = _clean_task_str("{}_{}".format(
         args.uid if args.uid else "",
         "_".join(["{}{}".format(k, v) for k, v in filtered.items()])
@@ -643,8 +643,9 @@ def get_name(args):
                            .replace('log_logistic_256', 'll256')
                            .replace('pixelcnn', 'pcnn')
                            .replace('isotropic_gaussian', 'ig')
-                           .replace('bernoulli', 'bern')
-                           .replace('mixture', 'mix')
+                           .replace('bernoulli', 'B')
+                           .replace('discrete', 'D')
+                           .replace('mixture', 'M')
                            .replace('parallel', 'par')
                            .replace('coordconv', 'cc')
                            .replace('dense', 'd')
@@ -663,6 +664,10 @@ def get_name(args):
                            .replace('uniform', 'u')
                            .replace('additive_vrnn', 'avrnn')
                            .replace('orthogonal', 'o')
+                           .replace('gaussian', 'N')
+                           .replace('cosine', 'cos')
+                           .replace('lars_', 'l')
+                           .replace('momentum', 'mom')
     )
 
     # sanity check to ensure filename is 255 chars or less for being able to write to filesystem

--- a/utils.py
+++ b/utils.py
@@ -1,14 +1,13 @@
 # coding: utf-8
 
 import os
+import socket
 import torch
 import torchvision
 import torch.nn as nn
 import numpy as np
-import scipy as sp
 import contextlib
 import torch.nn.functional as F
-import torch.distributions as D
 
 from itertools import chain
 from collections import Counter
@@ -31,6 +30,7 @@ def flatten(input_list):
 
     """
     return list(chain.from_iterable(input_list))
+
 
 def pca_reduce(x, num_reduce):
     '''reduced matrix X to num_reduce features'''
@@ -79,56 +79,9 @@ def squeeze_expand_dim(tensor, axis):
 
 
 def inv_perm(arr, perm):
+    """Given an array [B, *] and a permutation array [B], invert the operation returning array"""
     idx_perm = torch.cat([(perm == i).nonzero() for i in range(len(perm))], 0).squeeze()
     return arr[idx_perm]
-
-
-def normalize_images(imgs, mu=None, sigma=None, eps=1e-9):
-    ''' normalize imgs with provided mu /sigma
-        or computes them and returns with the normalized
-       images and tabulated mu / sigma'''
-    if mu is None:
-        if len(imgs.shape) == 4:
-            chans = imgs.shape[1]
-            mu = np.asarray(
-                [np.mean(imgs[:, i, :, :]) for i in range(chans)]
-            ).reshape(1, -1, 1, 1)
-        elif len(imgs.shape) == 5:  # glimpses
-            chans = imgs.shape[2]
-            mu = np.asarray(
-                [np.mean(imgs[:, :, i, :, :]) for i in range(chans)]
-            ).reshape(1, 1, -1, 1, 1)
-            sigma = np.asarray(
-                [np.std(imgs[:, :, i, :, :]) for i in range(chans)]
-            ).reshape(1, 1, -1, 1, 1)
-        else:
-            raise Exception("unknown number of dims for normalization")
-
-    if sigma is None:
-        if len(imgs.shape) == 4:
-            chans = imgs.shape[1]
-            sigma = np.asarray(
-                [np.std(imgs[:, i, :, :]) for i in range(chans)]
-            ).reshape(1, -1, 1, 1)
-        elif len(imgs.shape) == 5:  # glimpses
-            chans = imgs.shape[2]
-            sigma = np.asarray(
-                [np.std(imgs[:, :, i, :, :]) for i in range(chans)]
-            ).reshape(1, 1, -1, 1, 1)
-        else:
-            raise Exception("unknown number of dims for normalization")
-
-    return (imgs - mu) / (sigma + eps), [mu, sigma]
-
-
-def normalize_train_test_images(train_imgs, test_imgs, eps=1e-9):
-    ''' simple helper to take train and test images
-        and normalize the test images by the train mu/sigma '''
-    assert len(train_imgs.shape) == len(test_imgs.shape) >= 4
-
-    train_imgs , [mu, sigma] = normalize_images(train_imgs, eps=eps)
-    return [train_imgs,
-            (test_imgs - mu) / (sigma + eps)]
 
 
 def add_noise_to_imgs(imgs, disc_level=256.):
@@ -166,6 +119,7 @@ def is_cuda(tensor_or_var):
 
 def zeros_like(tensor):
     return torch.zeros_like(tensor)
+
 
 def ones(shape, cuda, dtype='float32'):
     shape = list(shape) if isinstance(shape, tuple) else shape
@@ -229,7 +183,7 @@ def merge_masks_into_imgs(imgs, masks_list):
 
         masks_gathered = torch.cat([masks_gathered, zeros, zeros], 2)
 
-    #print("masks gathered = ", masks_gathered.size())
+    # print("masks gathered = ", masks_gathered.size())
 
     # add C - channel
     imgs_gathered = expand_dims(imgs, 1) if len(imgs.size()) < 4 else imgs
@@ -295,6 +249,7 @@ def plot_tensor_grid(batch_tensor, save_filename=None):
 
 
 def plot_gaussian_tsne(z_mu_tensor, classes_tensor, prefix_name):
+    """Creates a TSNE plot given a [B, F] z_mu tensor, a list of corresponding classes and prefix for the file."""
     import matplotlib
     matplotlib.use('Agg')
     import matplotlib.pyplot as plt
@@ -321,7 +276,7 @@ def ewma(data, window):
     if not isinstance(data, np.ndarray):
         data = np.array(data)
 
-    alpha = 2 /(window + 1.0)
+    alpha = 2 / (window + 1.0)
     alpha_rev = 1-alpha
     n = data.shape[0]
 
@@ -336,7 +291,9 @@ def ewma(data, window):
     out = offset + cumsums*scale_arr[::-1]
     return out
 
+
 def zero_pad_smaller_cat(cat1, cat2):
+    """Given two categoricals zero pad the smaller one to make equivalent to the bigger one."""
     c1shp = cat1.size()
     c2shp = cat2.size()
     cuda = is_cuda(cat1)
@@ -417,6 +374,7 @@ def pad(tensor_or_var, num_pad, value=0, prepend=False, dim=-1):
 def int_type(use_cuda):
     return torch.cuda.IntTensor if use_cuda else torch.IntTensor
 
+
 def hash_to_size(text, size=-1):
     """ Get a hashed value for the provided text upto size
 
@@ -430,6 +388,7 @@ def hash_to_size(text, size=-1):
     hash_object = hashlib.sha1(str.encode(text))
     hex_dig = hash_object.hexdigest()
     return hex_dig[0:size]
+
 
 def get_aws_instance_id(timeout=2):
     """ Returns the AWS instance id or None
@@ -448,6 +407,25 @@ def get_aws_instance_id(timeout=2):
 
     return hash_to_size(r.text, 4)
 
+
+def get_ip_address_and_hostname(hostname=None):
+    """Simple helper to get the ip address and hostname.
+
+    :param hostname: None here grabs the local machine hostname
+    :returns: ip address, hostname
+    :rtype: str, str
+
+    """
+    hostname = socket.gethostname() if hostname is None else hostname
+    ip_addr = socket.gethostbyname(hostname)
+    return ip_addr, hostname
+
+
+def get_slurm_id():
+    """Simple helper to get the slurm job id."""
+    return os.environ.get('SLURM_JOBID', None)
+
+
 def long_type(use_cuda):
     return torch.cuda.LongTensor if use_cuda else torch.LongTensor
 
@@ -455,11 +433,13 @@ def long_type(use_cuda):
 def oneplus(x):
     return F.softplus(x, beta=1)
 
+
 def number_of_parameters(model, only_required_grad=False):
     if only_required_grad:
         return sum(p.numel() for p in model.parameters() if p.requires_grad)
 
     return sum(p.numel() for p in model.parameters() if p.requires_grad)
+
 
 def add_weight_norm(module):
     params = [p[0] for p in module.named_parameters()]
@@ -522,8 +502,8 @@ def network_to_half(network):
 
 
 def nan_check_and_break(tensor, name=""):
-        if nan_check(tensor, name) is True:
-            exit(-1)
+    if nan_check(tensor, name) is True:
+        exit(-1)
 
 
 def nan_check(tensor, name=""):
@@ -590,8 +570,10 @@ def get_name(args):
     vargs = deepcopy(vars(args))
     blacklist_keys = ['visdom_url', 'visdom_port', 'data_dir', 'download', 'cuda', 'uid',
                       'debug_step', 'detect_anomalies', 'model_dir', 'calculate_fid_with',
-                      'input_shape', 'fid_model_dir', 'output_dir']
-    filtered = {k:v for k,v in vargs.items() if k not in blacklist_keys} # remove useless info
+                      'input_shape', 'fid_model_dir', 'output_dir', 'gpu',
+                      'num_train_samples', 'num_test_samples', 'num_valid_samples', 'workers_per_replica',
+                      'steps_per_epoch', 'total_steps', 'distributed_master', 'distributed_port']
+    filtered = {k: v for k, v in vargs.items() if k not in blacklist_keys}  # remove useless info
 
     def _factor(name):
         ''' returns first characters of strings with _ separations'''
@@ -624,14 +606,17 @@ def get_name(args):
     bool2int = lambda v: int(v) if isinstance(v, bool) else v
     none2bool = lambda v: 0 if v is None else v
     nonestr2bool = lambda v: 0 if isinstance(v, str) and v.lower().strip() == 'none' else v
-    # clip2int = lambda v: int(v) if isinstance(v, (float, np.float32, np.float64)) and v == 0.0 else v
     clip2int = lambda v: int(v) if isinstance(v, float) and v - int(v) == 0 else v
-    filtered = {_factor(k):clip2int(nonestr2bool(none2bool(bool2int(v)))) for k, v in filtered.items()}
+    filtered = {_factor(k): clip2int(nonestr2bool(none2bool(bool2int(v)))) for k, v in filtered.items()}
+    filtered = {k: v for k, v in filtered.items() if v != 0}  # Removed 0-valued entries to save space
+
     name = _clean_task_str("{}_{}".format(
         args.uid if args.uid else "",
         "_".join(["{}{}".format(k, v) for k, v in filtered.items()])
-    ).replace('batchnorm', 'bn').replace('batch_groupnorm', 'bgn')
-                           .replace('groupnorm', 'gn')
+    ).replace('groupnorm', 'gn')
+                           .replace('sync_batchnorm', 'sbn')
+                           .replace('batchnorm', 'bn')
+                           .replace('batch_groupnorm', 'bgn')
                            .replace('instancenorm', 'in')
                            .replace('weightnorm', 'wn')
                            .replace('pixel_wise', 'pw')
@@ -642,7 +627,7 @@ def get_name(args):
                            .replace('disc_mix_logistic', 'dml')
                            .replace('log_logistic_256', 'll256')
                            .replace('pixelcnn', 'pcnn')
-                           .replace('isotropic_gaussian', 'ig')
+                           .replace('isotropic_gaussian', 'N')
                            .replace('bernoulli', 'B')
                            .replace('discrete', 'D')
                            .replace('mixture', 'M')
@@ -669,6 +654,13 @@ def get_name(args):
                            .replace('lars_', 'l')
                            .replace('momentum', 'mom')
                            .replace('autoencoder', 'ae')
+                           .replace('nih_chest_xray', 'xray')
+                           .replace('multi_image_folder', 'mimfolder')
+                           .replace('crop_dual_imagefolder', 'cdimfolder')
+                           .replace('image_folder', 'imfolder')
+                           .replace('celeba_sequential', 'sceleba')
+                           .replace('starcraft_predict_battle', 'sc2')
+                           .replace('svhn_centered', 'svhn')
     )
 
     # sanity check to ensure filename is 255 chars or less for being able to write to filesystem


### PR DESCRIPTION
  - Add BigGAN style decoders
  - More `nn.Module` based layers for specific sizes rather than trying to capture any arbritrary size. eg: `Conv32Encoder`, `Resnet32Decoder`, etc.
  - Weight norm that ignored bias / bn
  - Polyak Averaging
  - SyncBN support
  - DDP pytorch support
  - Linear Warmup + Cosine Annealer (for KLD, not scheduler)
  - Linear Warmup + Fixed Value (for KLD, not scheduler)
  - TODO: EvoNormS0 (currently broken)
  - DDP Wrapper for getting members